### PR TITLE
Remove caching of WSDL when making requests

### DIFF
--- a/lib/netsuite/configuration.rb
+++ b/lib/netsuite/configuration.rb
@@ -16,7 +16,7 @@ module NetSuite
 
     def connection(params={}, credentials={})
       client = Savon.client({
-        wsdl: cached_wsdl || ((credentials[:wsdl] && !credentials[:wsdl].empty?) ? credentials[:wsdl] : wsdl),
+        wsdl: (credentials[:wsdl] && !credentials[:wsdl].empty?) ? credentials[:wsdl] : wsdl,
         read_timeout: read_timeout,
         namespaces: namespaces,
         soap_header: auth_header(credentials).update(soap_header),
@@ -26,7 +26,6 @@ module NetSuite
         log_level: log_level,
         log: !silent, # turn off logging entirely if configured
       }.update(params))
-      cache_wsdl(client)
       return client
     end
 


### PR DESCRIPTION
We've found that the Netsuite gem caches the WSDL at the app level. This means it will force the same WSDL for all accounts that are connected to the same instance of the app (whatever wsdl is used in the first request).

In Mavenlink Integrations, we need to allow some customers to use a different wsdl for connecting with netsuite sandbox accounts. Caching gets in the way of this, so we are removing this functionality.

Of note, up until 4/12/17 we pointed to the mavenlink_additions branch of the netsuite gem, which did not use wsdl caching.