### PR TITLE
Ie 507 Ruby 3 Compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,26 @@ record = NetSuite::Records::CustomRecord.new(internal_id: 100)
 record.custom_field_list.custrecord_locationstate = "New Jersey"
 record.update(custom_field_list: record.custom_field_list, rec_type: NetSuite::Records::CustomRecord.new(internal_id: 10))
 
+# using get_select_value with a standard record
+NetSuite::Records::BaseRefList.get_select_value(
+  recordType: 'serviceSaleItem',
+  field: 'taxSchedule'
+)
+
+# get options for a custom sublist field (i.e. transaction column fields)
+NetSuite::Records::BaseRefList.get_select_value(
+  field: 'custcol69_2',
+  sublist: 'itemList',
+  recordType: 'salesOrder'
+)
+
+# output names of options available for a custom field
+options = NetSuite::Records::BaseRefList.get_select_value(
+  field: 'custbody_order_source',
+  recordType: 'invoice'
+)
+options.base_refs.map(&:name)
+
 ```
 
 #### Searching

--- a/lib/netsuite.rb
+++ b/lib/netsuite.rb
@@ -5,6 +5,7 @@ require 'netsuite/version'
 require 'netsuite/errors'
 require 'netsuite/utilities'
 require 'netsuite/core_ext/string/lower_camelcase'
+require 'netsuite/core_ext/uri/unescape'
 
 module NetSuite
   autoload :Configuration, 'netsuite/configuration'

--- a/lib/netsuite/core_ext/uri/unescape.rb
+++ b/lib/netsuite/core_ext/uri/unescape.rb
@@ -1,0 +1,3 @@
+module URI
+    class << self
+        def escape(str)

--- a/lib/netsuite/core_ext/uri/unescape.rb
+++ b/lib/netsuite/core_ext/uri/unescape.rb
@@ -1,3 +1,13 @@
+require 'uri'
+
 module URI
     class << self
+        def unescape(str)
+            CGI.unescape(str)
+        end
+
         def escape(str)
+            CGI.escape(str)
+        end
+    end
+end

--- a/netsuite.gemspec
+++ b/netsuite.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'savon', '~> 2.3.0'
 
-  gem.add_development_dependency 'rspec', '~> 3.1.0'
+  gem.add_development_dependency 'rspec', '~> 3.12.0'
 end


### PR DESCRIPTION
- Update RSpec to work with Rubymine spec formatter.
- Add Github Workflow for RSpec CI.
- Updated Savon gem dependency since older versions of the Savon gem are not compatible with Ruby 3 

